### PR TITLE
Improvements for SR2024

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -3,11 +3,6 @@ name: Build binaries
 on:
   - push
   - workflow_dispatch
-# on:
-#   push:
-#     branches: [ master ]
-#   pull_request:
-#     branches: [ master ]
 
 jobs:
   build:
@@ -21,10 +16,10 @@ jobs:
       uses: carlosperate/arm-none-eabi-gcc-action@v1
       with:
         release: 11.2-2022.02
-    - name: Set up Python 3.7
+    - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.9
     - name: Build libopencm3
       run: make lib
     - name: Make main binary

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Since the serial port is virtual, the baudrate is unused and can be set to any v
 Action | Description | Command | Parameter Description | Return | Return Parameters
 --- | --- | --- | --- | --- | ---
 Identify | Get the board type and version | *IDN? | - | Student Robotics:PBv4B:\<asset tag>:\<software version> | \<asset tag> <br>\<software version>
-Status | Get board status | *STATUS? | - | \<port overcurrents>:\<temp>:\<fan> | \<port overcurrents> - comma seperated list of 1/0s indicating if a port has reached overcurrent e.g. 1,0,0,0,0,0,0 -> \<H0>,\<H1>,\<L0>,\<L1>,\<L2>,\<L3>,\<Reg> -> H0 has overcurrent<br>\<temp> - board temperature in degrees celcius<br>\<fan> - fan is running, int, 0-1
+Status | Get board status | *STATUS? | - | \<port overcurrents>:\<temp>:\<fan>:\<reg voltage> | \<port overcurrents> - comma seperated list of 1/0s indicating if a port has reached overcurrent e.g. 1,0,0,0,0,0,0 -> \<H0>,\<H1>,\<L0>,\<L1>,\<L2>,\<L3>,\<Reg> -> H0 has overcurrent<br>\<temp> - board temperature in degrees celcius<br>\<fan> - fan is running, int, 0-1<br>\<reg voltage> - Voltage of 5 Volt regulator in mV
 Reset | Reset board to safe startup state<br>- Turn off all outputs<br>- Reset the lights, turn off buzzer | *RESET | - | ACK | -
 Start button | Detect if the internal and external start button has been pressed since this command was last invoked | BTN:START:GET? | - | \<int start pressed>:\<ext start pressed> | \<pressed> - button pressed, int, 0-1
 enable/disable output | Turn a power board output on or off | OUT:\<n>:SET:\<state> | \<n> port number, int,  0-6<br>\<state> int, 0-1 | ACK | - |

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ is `0010`.
 
 The Power Board is controlled over USB serial, each command is its own line.
 
+Since the serial port is virtual, the baudrate is unused and can be set to any value.
+
 ### Serial Commands
 
 Action | Description | Command | Parameter Description | Return | Return Parameters

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ Get run LED state | Get current Run LED output state | LED:RUN:GET? | - | \<valu
 Get error LED state | Get current Error LED output state | LED:ERR:GET? | - | \<value> | \<value> - LED value, enum, 0,1,F (flash)
 play note | Play note on the power board buzzer<br>Overwrites previous note | NOTE:\<note>:\<dur> | \<note> what note to play, int, 8-10,000Hz<br>\<dur> duration to play, int32, >0ms | ACK | -
 get current note |  | NOTE:GET? | - | \<freq>:\<remaining> | \<freq> - current tome frequency in Hz, int<br>\<remaining> - remaining tone duration in ms, int32 <br> Note: Both values are 0 if the buzzer is not running
+Force fan on | Override temperature control and runt the fan continually | *SYS:FAN:SET:\<value> | \<value> Enable/disable fan control override | ACK | - |
+enable/disable brain output | Turn the brain output on or off | *SYS:BRAIN:SET:\<state> | \<state> int, 0-1 | ACK | - |
+Modify overcurrent holdoff periods | | *SYS:DELAY_COEFF:SET:\<adc_oc>:\<batt_oc>:\<reg_oc>:\<uvlo_oc>:\<neg_batt_oc> | \<adc_oc> Holdoff in ms of an overcurrent reading on the individual 12V outputs, uint32<br>\<batt_oc> Holdoff in ms of an overcurrent reading on the global input, uint32<br>\<reg_oc> Holdoff in ms of an overcurrent reading on the 5V regulator output, uint32<br>\<uvlo_oc> Holdoff in ms of an undervoltage reading on the global input, uint32<br>\<neg_batt_oc> Holdoff in ms of a negative overcurrent reading on the global input, uint32 | ACK | - |
+Read current overcurrent holdoff periods | | *SYS:DELAY_COEFF:GET? | - | \<adc_oc>:\<batt_oc>:\<reg_oc>:\<uvlo_oc>:\<neg_batt_oc> |\<adc_oc> Holdoff in ms of an overcurrent reading on the individual 12V outputs, uint32<br>\<batt_oc> Holdoff in ms of an overcurrent reading on the global input, uint32<br>\<reg_oc> Holdoff in ms of an overcurrent reading on the 5V regulator output, uint32<br>\<uvlo_oc> Holdoff in ms of an undervoltage reading on the global input, uint32<br>\<neg_batt_oc> Holdoff in ms of a negative overcurrent reading on the global input, uint32 |
+
+The *SYS commands are for internal use and are not intended for end-users.
 
 The output numbers are:
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ read battery voltage | Read the battery voltage | BATT:V? | - | \<voltage> | \<v
 read battery current | Read the global current draw | BATT:I? | - | \<current> | \<current> - current, int, measured in mA
 Run LED | Set Run LED output | LED:RUN:SET:\<value> | \<value> LED value, enum, 0,1,F (flash) | ACK | -
 Error LED | Set Error LED output | LED:ERR:SET:\<value> | \<value> LED value, int, 0,1,F (flash) | ACK | -
+Get run LED state | Get current Run LED output state | LED:RUN:GET? | - | \<value> | \<value> - LED value, enum, 0,1,F (flash)
+Get error LED state | Get current Error LED output state | LED:ERR:GET? | - | \<value> | \<value> - LED value, enum, 0,1,F (flash)
 play note | Play note on the power board buzzer<br>Overwrites previous note | NOTE:\<note>:\<dur> | \<note> what note to play, int, 8-10,000Hz<br>\<dur> duration to play, int32, >0ms | ACK | -
+get current note |  | NOTE:GET? | - | \<freq>:\<remaining> | \<freq> - current tome frequency in Hz, int<br>\<remaining> - remaining tone duration in ms, int32 <br> Note: Both values are 0 if the buzzer is not running
 
 The output numbers are:
 

--- a/scripts/commission.py
+++ b/scripts/commission.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+import argparse
+import subprocess
+import tempfile
+from time import sleep
+from pathlib import Path
+
+import serial
+from serial.serialutil import SerialException
+
+from insert_serial import pad_serial, insert_bin_serial
+
+BOARD_TYPE = 'PBv4B'
+BOARD_VID = '1bda'
+BOARD_PID = '0010'
+SERIAL_NUM_ADDR = 0x1FE0
+
+
+def dfu_flash_firmware(firmware):
+    subprocess.run(['dfu-util', '-E', '1', '-d', f'{BOARD_VID}:{BOARD_PID}', '-D', firmware])
+
+    sleep(1)
+
+
+def serial_flash_firmware(port, firmware):
+    print(
+        "To flash the board using the factory bootloader you need to connect "
+        "12 volts to the board and connect both the USB and serial ports.")
+    input('Press enter once this is done')
+
+    # # Force board into ROM bootloader by pulling RTS at power on
+    # ser = serial.Serial(port)
+    # ser.rts = False
+    # input('Press the power button on the board twice, then press enter')
+    # ser.close()
+
+    asset_code = input("Enter asset code to bake into the bootloader: ")
+    asset_code = 'sr' + asset_code.upper()
+    print(f"Programming asset code: {asset_code}")
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        tmpdir = Path(tmpdirname)
+
+        # Apply asset code to bootloader
+        stock_data = Path(firmware).read_bytes()
+        data = insert_bin_serial(stock_data, pad_serial(asset_code, 16), SERIAL_NUM_ADDR)
+
+        # write fw w/ serial num to temp file
+        fw_file = tmpdir / 'main.bin'
+        fw_file.write_bytes(data)
+
+        # Flash bootloader+fw bundle w/ stm32flash
+        subprocess.check_call(['stm32flash', '-b', '115200', '-w', str(fw_file), '-v', '-R', port])
+    sleep(3)
+    return asset_code
+
+
+def verify_firmware(version, expected_serial=None):
+    try:
+        s = serial.serial_for_url(f'hwgrep://{BOARD_VID}:{BOARD_PID}', timeout=3, baudrate=115200)
+        s.flush()
+        s.write(b'*IDN?\n')
+        identity_raw = s.readline()
+        if not identity_raw.endswith(b'\n'):
+            print(f"Board did not correctly respond to identify, returned: {identity_raw!r}")
+            return False
+
+        identity = identity_raw.decode('utf-8').strip().split(':')
+        if identity[0] != 'Student Robotics':
+            print("Incorrect manufacturer returned")
+            return False
+        if identity[1] != BOARD_TYPE:
+            print("Incorrect board type returned")
+            return False
+        if identity[3] != version:
+            print('Incorrect version returned')
+            return False
+        if expected_serial is not None and identity[2] != expected_serial:
+            print(f"Serial number differs from expected, received {identity[2]!r}")
+            return False
+
+        print(f"Successfully flashed {identity[2]}")
+        return identity[2]
+
+    except SerialException:
+        print("Failed to open serial port")
+    return False
+
+
+def log_success(log_file, asset_code):
+    with open(log_file, 'a') as f:
+        f.write(f"{asset_code}\n")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('file', help="Firmware file to flash")
+    parser.add_argument('version', help="The version number the new firmware reports")
+    parser.add_argument('-log', '--serial_log', default=None, help="File to store serials successfully flashed")
+    parser.add_argument('--bootloader', action='store_true', help="Also Flash the bootloader to the board, this uses stm32flash")
+    parser.add_argument('--port', default="", help="The serial port to use for flashing the bootloader")
+
+    args = parser.parse_args()
+
+    try:
+        expected_asset = None
+        while True:
+            input('Press enter to flash power board')
+            if args.bootloader:
+                try:
+                    expected_asset = serial_flash_firmware(args.port, args.file)
+                except (subprocess.CalledProcessError, SerialException):
+                    print("Failed to flash firmware, try again")
+                    continue
+            else:
+                dfu_flash_firmware(args.file)
+            verified_code = verify_firmware(args.version, expected_asset)
+            if verified_code is not False and args.serial_log is not None:
+                log_success(args.serial_log, verified_code)
+    except (KeyboardInterrupt, EOFError):
+        return
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/commission.py
+++ b/scripts/commission.py
@@ -34,7 +34,7 @@ def serial_flash_firmware(port, firmware):
     # input('Press the power button on the board twice, then press enter')
     # ser.close()
 
-    asset_code = input("Enter asset code to bake into the bootloader: ")
+    asset_code = input("Enter asset code to bake into the bootloader (will have sr prepended): ")
     asset_code = 'sr' + asset_code.upper()
     print(f"Programming asset code: {asset_code}")
 

--- a/scripts/insert_serial.py
+++ b/scripts/insert_serial.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+import argparse
+from pathlib import Path
+
+
+def pad_serial(serial_num, length=16):
+    ""
+    # Trim and pad to one below length to allow for a null terminator
+    serial_num_truncated = serial_num[:length - 1]
+    serial_num_padded = serial_num_truncated.ljust(length - 1, '\0')
+
+    return serial_num_padded + '\0'
+
+
+def insert_bin_serial(data, serial_num, addr):
+    ""
+    data_array = bytearray(data)  # make the data mutable
+
+    serial_bytes = serial_num.encode('ascii')
+    length = len(serial_bytes)
+
+    # insert serial using slicing
+    data_array[addr:(addr + length)] = serial_bytes
+
+    return bytes(data_array)
+
+
+def ExistingFile(val):
+    """ To be used as an argparse argument type
+        Tests the file exists without opening it to avoid issues with files
+        not being closed: https://bugs.python.org/issue13824
+    """
+    f = Path(val)
+    try:
+        if not f.is_file():
+            raise argparse.ArgumentTypeError(f'File not found {val}')
+    except PermissionError as e:
+        raise argparse.ArgumentTypeError(e)
+
+    return f
+
+
+def ValidPath(val):
+    """ To be used as an argparse argument type
+        Tests the filepath exists without creating it to avoid issues with
+        files not being closed: https://bugs.python.org/issue13824
+    """
+    f = Path(val)
+    try:
+        if not f.parent.is_dir():
+            raise argparse.ArgumentTypeError(f'Path does not exist {val}')
+    except PermissionError as e:
+        raise argparse.ArgumentTypeError(e)
+
+    return f
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Insert a serial number into a pre-compiled binary"
+    )
+    parser.add_argument(
+        '-a', '--address', type=int, default=0x1FE0,
+        help=(
+            "The address offset from the start of the file to place the "
+            "serial number (defaults to 0x1FE0)"
+        )
+    )
+    parser.add_argument(
+        '-l', '--length', type=int, default=16,
+        help="The length of the serial number placeholder, including the null terminator (defaults to 16)"
+    )
+    parser.add_argument('serial_num', help="The value to set the serial number to.")
+    parser.add_argument(
+        'infile', type=ExistingFile,
+        help="The template file to insert the serial number into.",
+    )
+    parser.add_argument(
+        'outfile', type=ValidPath,
+        help="The file to write the output to.",
+    )
+
+    args = parser.parse_args()
+
+    data = args.infile.read_bytes()
+    serial_num = pad_serial(args.serial_num, args.length)
+    new_data = insert_bin_serial(data, serial_num, args.address)
+
+    args.outfile.write_bytes(new_data)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prepend_bootloader.py
+++ b/scripts/prepend_bootloader.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+import argparse
+from pathlib import Path
+
+def prepend_bootloader(bootloader_file, fw_file, output_file):
+    bootloader = Path(bootloader_file).read_bytes()
+    firmware = Path(fw_file).read_bytes()
+
+    output = bootloader + firmware
+
+    Path(output_file).write_bytes(output)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('bootloader', help="Bootloader file")
+    parser.add_argument('firmware', help="Firmware file")
+    parser.add_argument('output', help="Output file")
+
+    args = parser.parse_args()
+
+    prepend_bootloader(args.bootloader, args.firmware, args.output)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,7 +17,7 @@
 ## You should have received a copy of the GNU Lesser General Public License
 ## along with this library.  If not, see <http://www.gnu.org/licenses/>.
 ##
-FW_VER ?= 4.4
+FW_VER ?= 4.4.1
 
 # Name of C file with main function
 BINARY = main

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,7 +17,7 @@
 ## You should have received a copy of the GNU Lesser General Public License
 ## along with this library.  If not, see <http://www.gnu.org/licenses/>.
 ##
-FW_VER ?= 4.4.1
+FW_VER ?= 4.4.2
 
 # Name of C file with main function
 BINARY = main

--- a/src/buzzer.c
+++ b/src/buzzer.c
@@ -6,6 +6,7 @@
 
 
 volatile uint32_t buzzer_ticks_remaining = 0;
+uint16_t buzzer_frequency = 0;
 
 void buzzer_init(void) {
     // Enable TIM3 clock
@@ -39,6 +40,7 @@ void buzzer_note(uint16_t freq, uint32_t duration) {
 
     // Set timer period for frequency
     timer_set_period(TIM3, (1000000 / 2) / freq);
+    buzzer_frequency = freq;
 
     // Enable timer
     timer_enable_counter(TIM3);
@@ -63,4 +65,15 @@ void buzzer_tick(void) {
             buzzer_stop();
         }
     }
+}
+
+uint16_t buzzer_get_freq(void) {
+    if (buzzer_running()) {
+        return buzzer_frequency;
+    } else {
+        return 0;
+    }
+}
+uint32_t buzzer_remaining(void) {
+    return buzzer_ticks_remaining;
 }

--- a/src/buzzer.h
+++ b/src/buzzer.h
@@ -7,3 +7,6 @@ void buzzer_note(uint16_t freq, uint32_t duration);
 void buzzer_stop(void);
 bool buzzer_running(void);
 void buzzer_tick(void);
+
+uint16_t buzzer_get_freq(void);
+uint32_t buzzer_remaining(void);

--- a/src/global_vars.h
+++ b/src/global_vars.h
@@ -23,6 +23,7 @@
 extern volatile INA219_meas_t battery;
 extern volatile INA219_meas_t reg_5v;
 extern volatile int16_t board_temp;
+extern volatile bool fan_override;
 
 extern volatile bool int_button_pressed;
 extern volatile bool ext_button_pressed;

--- a/src/global_vars.h
+++ b/src/global_vars.h
@@ -27,8 +27,8 @@ extern volatile int16_t board_temp;
 extern volatile bool int_button_pressed;
 extern volatile bool ext_button_pressed;
 
-extern volatile uint8_t ADC_OVERCURRENT_DELAY;
-extern volatile uint8_t BATT_OVERCURRENT_DELAY;
-extern volatile uint8_t REG_OVERCURRENT_DELAY;
-extern volatile uint8_t UVLO_DELAY;
+extern volatile uint16_t ADC_OVERCURRENT_DELAY;
+extern volatile uint16_t BATT_OVERCURRENT_DELAY;
+extern volatile uint16_t REG_OVERCURRENT_DELAY;
+extern volatile uint16_t UVLO_DELAY;
 extern volatile uint16_t NEG_CURRENT_DELAY;

--- a/src/i2c.c
+++ b/src/i2c.c
@@ -2,14 +2,14 @@
 #include "global_vars.h"
 
 // AF bit is set when a byte transfer ends with a NACK
-static inline bool nack_recieved(void) {return I2C_SR1(I2C1) & I2C_SR1_AF;}
+static inline bool nack_received(void) {return I2C_SR1(I2C1) & I2C_SR1_AF;}
 static inline bool i2c_transaction_in_progress(void) {return I2C_SR2(I2C1) & I2C_SR2_BUSY;}
 
 // A timed out I2C device will NACK after receiving a byte
 #define I2C_RETURN_IF_FAILED(x) if(i2c_timed_out) { return x;}
 // The I2C protocol means that every transfer will end with either a NACK or ACK
-// The ACK requires the slave device to be actively participating in the transaction
-#define I2C_FAIL_AND_RETURN_ON_NACK(x) if(nack_recieved()) { \
+// The ACK requires the target device to be actively participating in the transaction
+#define I2C_FAIL_AND_RETURN_ON_NACK(x) if(nack_received()) { \
     i2c_timed_out = true; \
     if (i2c_transaction_in_progress()) {i2c_send_stop(I2C1);} return x;}
 
@@ -44,7 +44,7 @@ void i2c_start_message(uint8_t addr) {
     // Send START condition.
     i2c_send_start(I2C1);
 
-    // Waiting for START to send and switch to master mode.
+    // Waiting for START to send and switch to controller mode.
     while (!((I2C_SR1(I2C1) & I2C_SR1_SB)
         && (I2C_SR2(I2C1) & (I2C_SR2_MSL | I2C_SR2_BUSY))));
 
@@ -93,7 +93,7 @@ bool i2c_recv_bytes(uint8_t addr, uint8_t* buf, uint8_t len) {
     // Send START condition.
     i2c_send_start(I2C1);
 
-    // Waiting for START to send and switch to master mode.
+    // Waiting for START to send and switch to controller mode.
     while (!((I2C_SR1(I2C1) & I2C_SR1_SB)
         && (I2C_SR2(I2C1) & (I2C_SR2_MSL | I2C_SR2_BUSY))));
 

--- a/src/i2c.h
+++ b/src/i2c.h
@@ -5,7 +5,9 @@
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/stm32/gpio.h>
 
+// Value of current reading LSB on the INA219 in amps
 #define I_SENSE_LSB 0.001
+
 #define I_CAL_VAL(I_SHUNT_RES) ((uint16_t)(0.04096/(I_SHUNT_RES * I_SENSE_LSB)))
 #define INA219_CONF(PGA_MODE, ADC_MODE) ( 0x2000 | ((PGA_MODE & 0x3) << 11) | 0x180 | ((ADC_MODE & 0xF) << 3) | 0x7)
 

--- a/src/led.c
+++ b/src/led.c
@@ -87,7 +87,6 @@ void clear_led(uint32_t pin) {
     }
 }
 
-
 void toggle_led(uint32_t pin) {
     switch (pin) {
         case LED_RUN:
@@ -115,6 +114,39 @@ void toggle_led(uint32_t pin) {
         case LED_STATL3:
             gpio_toggle(GPIOB, pin);
             break;
+    }
+}
+
+uint8_t get_led_state(uint32_t pin) {
+    switch (pin) {
+        // active-low LEDs
+        case LED_RUN:
+            if (led_run_flashing) {
+                return 2;
+            }
+            return (gpio_get(GPIOB, pin)?0:1);
+        case LED_ERROR:
+            if (led_error_flashing) {
+                return 2;
+            }
+            return (gpio_get(GPIOB, pin)?0:1);
+        case LED_FLAT:
+            if (led_flat_flashing) {
+                return 2;
+            }
+            return (gpio_get(GPIOD, pin)?0:1);
+
+        // active-high LEDs
+        case LED_STATH0:
+        case LED_STATH1:
+            return (gpio_get(GPIOC, pin)?1:0);
+        case LED_STATL0:
+        case LED_STATL1:
+        case LED_STATL2:
+        case LED_STATL3:
+            return (gpio_get(GPIOB, pin)?1:0);
+        default:
+            return 0;
     }
 }
 

--- a/src/led.h
+++ b/src/led.h
@@ -18,6 +18,7 @@ void led_init(void);
 void set_led(uint32_t pin);
 void clear_led(uint32_t pin);
 void toggle_led(uint32_t pin);
+uint8_t get_led_state(uint32_t pin);
 
 void set_led_flash(uint32_t pin);
 void handle_led_flash(void);

--- a/src/main.c
+++ b/src/main.c
@@ -59,6 +59,8 @@ void init(void) {
     usb_init();
     led_init();
     i2c_init();
+    // Make sure all outputs are off before nulling out the I2C sensors
+    disable_all_outputs(true);
     init_i2c_sensors(true);
     button_init();
     fan_init();

--- a/src/main.c
+++ b/src/main.c
@@ -21,8 +21,9 @@ void jump_to_bootloader(void);
 int main(void) {
     init();
 
-    // Enable brain output
-    enable_output(BRAIN_OUTPUT, true);
+    // Enable brain output, by resetting the board
+    // This will clear the overcurrent flags that the init set
+    reset_board();
 
     // Signal we initialised
     set_led(LED_RUN);
@@ -60,6 +61,7 @@ void init(void) {
     led_init();
     i2c_init();
     // Make sure all outputs are off before nulling out the I2C sensors
+    // This will mark all outputs as overcurrent, we'll correct that after the init
     disable_all_outputs(true);
     init_i2c_sensors(true);
     button_init();

--- a/src/msg_handler.c
+++ b/src/msg_handler.c
@@ -336,6 +336,31 @@ void handle_msg(char* buf, char* response, int max_len) {
                 append_str(response, "NACK:Unknown brain command", max_len);
                 return;
             }
+        } else if (strcmp(next_arg, "FAN") == 0) {
+            next_arg = get_next_arg(response, "NACK:Missing fan command", max_len);
+            if(next_arg == NULL) {return;}
+            if (strcmp(next_arg, "SET") == 0) {
+                next_arg = get_next_arg(response, "NACK:Missing fan override argument", max_len);
+                if(next_arg == NULL) {return;}
+
+                if (next_arg[0] == '1') {
+                    fan_override = true;
+
+                    append_str(response, "ACK", max_len);
+                    return;
+                } else if (next_arg[0] == '0') {
+                    fan_override = false;
+
+                    append_str(response, "ACK", max_len);
+                    return;
+                }
+
+                append_str(response, "NACK:Invalid fan override argument", max_len);
+                return;
+            } else {
+                append_str(response, "NACK:Unknown fan command", max_len);
+                return;
+            }
         }
 
         append_str(response, "NACK:Invalid system command", max_len);

--- a/src/msg_handler.c
+++ b/src/msg_handler.c
@@ -53,6 +53,11 @@ void handle_msg(char* buf, char* response, int max_len) {
         if(next_arg == NULL) {return;}
 
         if (strcmp(next_arg, "SET") == 0) {
+            // inhibit setting brain port
+            if (output_num == BRAIN_OUTPUT) {
+                append_str(response, "NACK:Brain output cannot be controlled", max_len);
+                return;
+            }
             next_arg = get_next_arg(response, "NACK:Missing output enable argument", max_len);
             if(next_arg == NULL) {return;}
 
@@ -303,6 +308,32 @@ void handle_msg(char* buf, char* response, int max_len) {
                 return;
             } else {
                 append_str(response, "NACK:Unknown coefficient command", max_len);
+                return;
+            }
+        } else if (strcmp(next_arg, "BRAIN") == 0) {
+            next_arg = get_next_arg(response, "NACK:Missing brain command", max_len);
+            if(next_arg == NULL) {return;}
+            if (strcmp(next_arg, "SET") == 0) {
+                next_arg = get_next_arg(response, "NACK:Missing brain enable argument", max_len);
+                if(next_arg == NULL) {return;}
+
+                // Enable output
+                if (next_arg[0] == '1') {
+                    enable_output(BRAIN_OUTPUT, true);
+
+                    append_str(response, "ACK", max_len);
+                    return;
+                } else if (next_arg[0] == '0') {
+                    enable_output(BRAIN_OUTPUT, false);
+
+                    append_str(response, "ACK", max_len);
+                    return;
+                }
+
+                append_str(response, "NACK:Invalid brain enable argument", max_len);
+                return;
+            } else {
+                append_str(response, "NACK:Unknown brain command", max_len);
                 return;
             }
         }

--- a/src/msg_handler.c
+++ b/src/msg_handler.c
@@ -124,6 +124,21 @@ void handle_msg(char* buf, char* response, int max_len) {
 
             append_str(response, "NACK:Invalid LED value", max_len);
             return;
+        } else if (strcmp(next_arg, "GET?") == 0) {
+            switch(get_led_state(led)) {
+                case 0:
+                    append_str(response, "0", max_len);
+                    return;
+                case 1:
+                    append_str(response, "1", max_len);
+                    return;
+                case 2:
+                    append_str(response, "F", max_len);
+                    return;
+                default:
+                    append_str(response, "NACK:Failed to get pin state", max_len);
+                    return;
+            }
         }
         append_str(response, "NACK:Invalid LED argument", max_len);
         return;
@@ -179,6 +194,11 @@ void handle_msg(char* buf, char* response, int max_len) {
                 append_str(response, "NACK:Invalid note frequency", max_len);
                 return;
             }
+        } else if (strcmp(next_arg, "GET?") == 0) {
+            append_str(response, itoa(buzzer_get_freq(), temp_str), max_len);
+            append_str(response, ":", max_len);
+            append_str(response, itoa(buzzer_remaining(), temp_str), max_len);
+            return;
         } else {
             append_str(response, "NACK:Invalid note frequency", max_len);
             return;
@@ -237,8 +257,8 @@ void handle_msg(char* buf, char* response, int max_len) {
             if(next_arg == NULL) {return;}
 
             if (strcmp(next_arg, "SET") == 0) {
-                uint8_t new_coeffs[5];
-                uint16_t coeff;
+                uint16_t new_coeffs[5];
+                unsigned long coeff;
 
                 for(uint8_t i=0; i < 5; i++) {
                     next_arg = get_next_arg(response, "NACK:Missing coefficient set argument", max_len);
@@ -248,8 +268,8 @@ void handle_msg(char* buf, char* response, int max_len) {
                         coeff = strtoul(next_arg, NULL, 10);
 
                         // bounds check value
-                        if (coeff > (UINT8_MAX - 1)) {
-                            append_str(response, "NACK:Coefficient must fit in uint8", max_len);
+                        if (coeff > (UINT16_MAX - 1)) {
+                            append_str(response, "NACK:Coefficient must fit in uint16", max_len);
                             return;
                         }
                         // add value to array
@@ -264,9 +284,7 @@ void handle_msg(char* buf, char* response, int max_len) {
                 BATT_OVERCURRENT_DELAY = new_coeffs[1];
                 REG_OVERCURRENT_DELAY = new_coeffs[2];
                 UVLO_DELAY = new_coeffs[3];
-
-                coeff = new_coeffs[4];
-                NEG_CURRENT_DELAY = coeff << 6;
+                NEG_CURRENT_DELAY = new_coeffs[4];
 
                 append_str(response, "ACK", max_len);
                 return;

--- a/src/msg_handler.c
+++ b/src/msg_handler.c
@@ -243,6 +243,8 @@ void handle_msg(char* buf, char* response, int max_len) {
         append_str(response, itoa(board_temp, temp_str), max_len);
         append_str(response, ":", max_len);
         append_str(response, (fan_running()?"1":"0"), max_len);
+        append_str(response, ":", max_len);
+        append_str(response, itoa(reg_5v.voltage, temp_str), max_len);
         return;
     } else if (strcmp(next_arg, "*RESET") == 0) {
         reset_board();

--- a/src/output.c
+++ b/src/output.c
@@ -276,7 +276,7 @@ void detect_overcurrent(void) {
 void disable_all_outputs(bool disable_brain) {
     // Inhibit all outputs to prevent them being re-enabled
     for (output_t out=OUT_H0; out <= OUT_5V; out++) {
-        if ((!disable_brain) && (out == OUT_L2)) {continue;}
+        if ((!disable_brain) && (out == BRAIN_OUTPUT)) {continue;}
         _enable_output(out, false);
         output_inhibited[out] = true;
     }

--- a/src/output.c
+++ b/src/output.c
@@ -19,15 +19,15 @@ static const uint32_t OUTPUT_PIN[7]  = {GPIO10, GPIO11, GPIO6, GPIO7, GPIO8, GPI
 static const uint32_t OUTPUT_CSDIS_PIN[4] = {GPIO0, GPIO1, GPIO2, GPIO3};
 
 // In ms, ADC delay is in steps of 4, batt and reg are in multiples of 20
-volatile uint8_t ADC_OVERCURRENT_DELAY = 20;
-volatile uint8_t BATT_OVERCURRENT_DELAY = 20;
-volatile uint8_t REG_OVERCURRENT_DELAY = 20;
+volatile uint16_t ADC_OVERCURRENT_DELAY = 100;
+volatile uint16_t BATT_OVERCURRENT_DELAY = 100;
+volatile uint16_t REG_OVERCURRENT_DELAY = 20;
 volatile uint16_t NEG_CURRENT_DELAY = 2000;
-// In samples
-volatile uint8_t UVLO_DELAY = 1;
+// In ms
+volatile uint16_t UVLO_DELAY = 40;
 
-uint8_t overcurrent_delay[8] = {0};
-uint8_t uvlo_delay = 0;
+uint16_t overcurrent_delay[8] = {0};
+uint16_t uvlo_delay = 0;
 uint16_t neg_current_delay = 0;
 volatile uint16_t output_current[7] = {0};  // reg value here is unused
 volatile bool output_inhibited[7] = {0};
@@ -189,7 +189,7 @@ static void set_global_overcurrent(void) {
 void handle_uvlo(void) {
     // Test if global voltage is below 10.2V
     if ((battery.success) && (battery.voltage < 10200)) {
-        uvlo_delay++;
+        uvlo_delay+=20;
         if (uvlo_delay > UVLO_DELAY) {
             disable_all_outputs(true);
             set_led(LED_FLAT);

--- a/src/systick.c
+++ b/src/systick.c
@@ -14,6 +14,7 @@
 volatile INA219_meas_t battery = {0};
 volatile INA219_meas_t reg_5v = {0};
 volatile int16_t board_temp = 0;
+volatile bool fan_override = false;
 
 uint8_t systick_slow_tick = 0;
 uint16_t systick_temp_tick = 0;
@@ -58,7 +59,7 @@ void sys_tick_handler(void) {
         board_temp = adc_to_temp(get_adc_measurement(TEMP_SENSE_CHANNEL));
 
         // Set fan
-        if(board_temp > FAN_THRESHOLD) {
+        if((board_temp > FAN_THRESHOLD )|| fan_override) {
             fan_enable(true);
         } else if (board_temp < FAN_THRESHOLD) {  // 2 degree hysteresis
             fan_enable(false);

--- a/utils/rules.mk
+++ b/utils/rules.mk
@@ -138,7 +138,7 @@ TGT_LDFLAGS		+= --static -nostartfiles
 TGT_LDFLAGS		+= -T$(LDSCRIPT)
 TGT_LDFLAGS		+= $(ARCH_FLAGS) $(DEBUG)
 TGT_LDFLAGS		+= -Wl,-Map=$(*).map -Wl,--cref
-TGT_LDFLAGS		+= -Wl,--gc-sections
+TGT_LDFLAGS		+= -Wl,--gc-sections -Wl,--print-memory-usage
 ifeq ($(V),99)
 TGT_LDFLAGS		+= -Wl,--print-gc-sections
 endif


### PR DESCRIPTION
- Adds getter commands for LEDs and note to allow all borad state to be retrieved
- Adds scripts to commission boards with and without bootloaders
- Prevent brain output from being controlled through the output command
- Extend overcurrent hold-off time to allow for wider inrush peaks